### PR TITLE
Fix issue with servicesLogs

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -59,6 +59,7 @@ class CalrissianRunnerExecutionHandler(ExecutionHandler):
                 self.conf["service_logs"]={}
             for j in range(len(keys)):
                 self.conf["service_logs"][keys[j]]=servicesLogs[okeys[j]]
+        self.conf["service_logs"]["length"]=str(len(servicesLogs))
         pass
 
 

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -58,7 +58,7 @@ class CalrissianRunnerExecutionHandler(ExecutionHandler):
             if "service_logs" not in self.conf:
                 self.conf["service_logs"]={}
             for j in range(len(keys)):
-                self.conf["service_logs"][keys[j]]=servicesLogs[okeys[j]]
+                self.conf["service_logs"][keys[j]]=servicesLogs[i][okeys[j]]
         self.conf["service_logs"]["length"]=str(len(servicesLogs))
         pass
 

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -55,7 +55,7 @@ class CalrissianRunnerExecutionHandler(ExecutionHandler):
             if i>0:
                 for j in range(len(keys)):
                     keys[j]=keys[j]+"_"+str(i)
-            if "service_logs" not in conf:
+            if "service_logs" not in self.conf:
                 self.conf["service_logs"]={}
             for j in range(len(keys)):
                 self.conf["service_logs"][keys[j]]=servicesLogs[okeys[j]]

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -11,6 +11,11 @@ from zoo_calrissian_runner import ExecutionHandler, ZooCalrissianRunner
 class CalrissianRunnerExecutionHandler(ExecutionHandler):
 
     def local_get_file(self,fileName):
+        """
+        Read and load a yaml file
+
+        :param fileName the yaml file to load
+        """
         try:
             with open(fileName, 'r') as file:
                 additional_params = yaml.safe_load(file)
@@ -41,6 +46,16 @@ class CalrissianRunnerExecutionHandler(ExecutionHandler):
 
 
     def handle_outputs(self, log, output, usage_report, tool_logs):
+        """
+        Handle the output files of the execution.
+
+        :param log: The application log file of the execution.
+        :param output: The output file of the execution.
+        :param usage_report: The performance metrics file for the application during execution.
+        :param tool_logs: A list of paths to individual workflow step logs from the execution.
+
+        """
+        # link element to add to the statusInfo
         servicesLogs=[
             {
                 "url": f"{self.conf['main']['tmpUrl']}/{self.conf['lenv']['Identifier']}-{self.conf['lenv']['usid']}/{os.path.basename(tool_log)}",
@@ -60,7 +75,6 @@ class CalrissianRunnerExecutionHandler(ExecutionHandler):
             for j in range(len(keys)):
                 self.conf["service_logs"][keys[j]]=servicesLogs[i][okeys[j]]
         self.conf["service_logs"]["length"]=str(len(servicesLogs))
-        pass
 
 
 def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs):

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -43,7 +43,7 @@ class CalrissianRunnerExecutionHandler(ExecutionHandler):
     def handle_outputs(self, log, output, usage_report, tool_logs):
         servicesLogs=[
             {
-                "url": f"https://someurl.com/{os.path.basename(tool_log)}",
+                "url": f"{self.conf['main']['tmpUrl']}/{self.conf['lenv']['Identifier']}-{self.conf['lenv']['usid']}/{os.path.basename(tool_log)}",
                 "title": f"Tool log {os.path.basename(tool_log)}",
                 "rel": "related",
             }


### PR DESCRIPTION
Fix typo when accessing the `servicesLogs` array and add the `length` parameter required to detect the multiple values in a maps.

Use the correct location for the logs files by using the standard `tmpUrl` parameter from the `main`section. 